### PR TITLE
Revert "Add cygwin-devel"

### DIFF
--- a/build-cygwin.js
+++ b/build-cygwin.js
@@ -36,8 +36,7 @@ const install = async () => {
         "patch",
         "unzip",
         "python",
-        "bash",
-        "cygwin-devel"
+        "bash"
 
         // Needed for installing the cygwin-build of OCaml
         // May not be needed


### PR DESCRIPTION
Reverts esy/esy-bash#64

The mingw64 cross compiler isn't meant to look for these libraries. All Unixisms in the ecosystems will need a clean win32 implementations. cygwin.dll isn't meant to statically linked. See 6.13 and 6.14 at https://cygwin.com/faq/